### PR TITLE
Upgrade Guzzle to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7",
-        "guzzlehttp/guzzle": "^6"
+        "php": "^7.2",
+        "guzzlehttp/guzzle": "^7"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As far as i see there are no breaking changes in this project according to the Guzzle upgrade docs:
https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70

Upgrading because Laravel 8 required Guzzle 7.0
https://laravel.com/docs/8.x/upgrade#updating-dependencies